### PR TITLE
Feat/delete company profile

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -66,6 +66,26 @@ export default function ProfilePage() {
     },
   });
 
+  const { mutate: deleteCompany, isPending: isDeleteCompanyPending } = useMutation({
+    mutationFn: async () =>
+      await axios.delete(
+        BackendRoutes.COMPANIES_ID({ id: company?.id ?? "" }),
+      ),
+      onMutate: () => {
+        toast.loading("Deleting company...", { id: "delete-company" });
+      },
+      onError: () => {
+        toast.error("Failed to delete company", { id: "delete-company" });
+      },
+      onSuccess: () => {
+        toast.success("Company deleted successfully", { id: "delete-company" });
+        setIsEditDialogOpen(false);
+        queryClient.invalidateQueries({
+          queryKey: [BackendRoutes.COMPANIES_ID({ id: company?.id ?? "" })],
+        });
+      },
+  });
+
   if (isUserLoading || isCompanyLoading || status === "loading") return null;
 
   return (
@@ -93,7 +113,7 @@ export default function ProfilePage() {
                   <DropdownMenuItem onClick={() => setIsEditDialogOpen(true)}>
                     Edit Profile
                   </DropdownMenuItem>
-                  <DropdownMenuItem className="text-red-600 focus:text-red-600">
+                  <DropdownMenuItem className="text-red-600 focus:text-red-600" onClick={() => { if (confirm("Are you sure you want to delete this company profile?")) { deleteCompany(); }}}>
                     Delete Profile
                   </DropdownMenuItem>
                 </DropdownMenuContent>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -65,6 +65,26 @@ export default function ProfilePage() {
     },
   });
 
+  const { mutate: deleteCompany, isPending: isDeleteCompanyPending } = useMutation({
+    mutationFn: async () =>
+      await axios.delete(
+        BackendRoutes.COMPANIES_ID({ id: company?.id ?? "" }),
+      ),
+      onMutate: () => {
+        toast.loading("Deleting company...", { id: "delete-company" });
+      },
+      onError: () => {
+        toast.error("Failed to delete company", { id: "delete-company" });
+      },
+      onSuccess: () => {
+        toast.success("Company deleted successfully", { id: "delete-company" });
+        setIsEditDialogOpen(false);
+        queryClient.invalidateQueries({
+          queryKey: [BackendRoutes.COMPANIES_ID({ id: company?.id ?? "" })],
+        });
+      },
+  });
+
   if (isUserLoading || isCompanyLoading || status === "loading") return null;
 
   return (
@@ -92,7 +112,7 @@ export default function ProfilePage() {
                   <DropdownMenuItem onClick={() => setIsEditDialogOpen(true)}>
                     Edit Profile
                   </DropdownMenuItem>
-                  <DropdownMenuItem className="text-red-600 focus:text-red-600">
+                  <DropdownMenuItem className="text-red-600 focus:text-red-600" onClick={() => { if (confirm("Are you sure you want to delete this company profile?")) { deleteCompany(); }}}>
                     Delete Profile
                   </DropdownMenuItem>
                 </DropdownMenuContent>

--- a/src/components/dialog/DeleteCompanyProfileDialog.tsx
+++ b/src/components/dialog/DeleteCompanyProfileDialog.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/shadcn/alert-dialog";
+import { buttonVariants } from "@/components/ui/shadcn/button";
+
+interface DeleteCompanyDialogProps {
+  isOpen: boolean;
+  isPending: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+}
+
+export function DeleteCompanyProfileDialog({
+  isOpen,
+  isPending,
+  onClose,
+  onDelete,
+}: DeleteCompanyDialogProps) {
+  return (
+    <AlertDialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This action cannot be undone. This will permanently delete the company profile.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className={buttonVariants({ variant: "destructive" })}
+            onClick={() => onDelete()}
+            disabled={isPending}
+          >
+            {isPending ? "Deleting..." : "Delete"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}


### PR DESCRIPTION
## Proposed Changes

- Added the ability to delete a company profile by introducing a new DeleteCompanyProfileDialog component.
- Added a new state (isDeleteDialogOpen) for managing the visibility of the delete confirmation dialog.
- Added a deleteCompany mutation to handle the deletion of a company profile with success and error handling 
- Updated the dropdown menu to include a "Delete Profile" option that triggers the delete dialog.
- Displayed a button to create a company profile if one doesn't exist, redirecting the user to the company creation page.

## Related Information
- This change enhances the profile page with options for editing and deleting the company profile.
- Updated UI components to include a delete confirmation flow.

## Visual Changes

- **Before:**
The "Delete Profile" button existed but did not trigger any action upon clicking.
 No Company information
 ![image](https://github.com/user-attachments/assets/1539ca9d-8f81-46c4-a96f-949a1f1c22c0)

- **After:**
 The "Delete Profile" button opens a confirmation dialog that enables the deletion of the company profile.
 A button to create a company profile is displayed when no company profile exists. Clicking the button redirects the user to the company creation page.
 No Company information
![image](https://github.com/user-attachments/assets/31cc29f3-f4cb-4ad8-831e-bef6e3d344cf)


## Checklist

<!-- Mark completed items with an [x] -->

- [x] Code follows project style guidelines and frontend best practices
- [x] No console warnings or errors present
- [x] Reviewed own code
